### PR TITLE
Anti-Debug Api Call New Siganture

### DIFF
--- a/modules/signatures/injection_runpe.py
+++ b/modules/signatures/injection_runpe.py
@@ -53,7 +53,7 @@ class InjectionRUNPE(Signature):
            if self.get_argument(call, "ThreadHandle") in self.thread_handles:
                 self.sequence = 1
                 self.signs.append(call)
-        elif (call["api"] == "NtWriteVirtualMemory" or call["api"] == "WriteProcessMemory" or call["api"] == "NtMapViewOfSection") and (self.sequence == 1 or self.sequence == 2):
+        elif (call["api"] == "NtWriteVirtualMemory" or call["api"] == "WriteProcessMemory" or call["api"] == "ZwMapViewOfSection") and (self.sequence == 1 or self.sequence == 2):
             if self.get_argument(call, "ProcessHandle") in self.process_handles:
                 self.sequence = self.sequence + 1
                 self.signs.append(call)

--- a/modules/signatures/origin_langid.py
+++ b/modules/signatures/origin_langid.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class BuildLangID(Signature):
     name = "origin_langid"
-    description = "Unconventionial binary language"
+    description = "Unconventional binary language"
     severity = 2
     authors = ["Benjamin K.", "Kevin R.", "nex"]
     categories = ["origin"]

--- a/modules/signatures/packer_entropy.py
+++ b/modules/signatures/packer_entropy.py
@@ -34,7 +34,7 @@ class PackerEntropy(Signature):
                 for section in self.results["static"]["pe_sections"]:
                     total_pe_data += int(section["size_of_data"], 16)
                      
-                    if section["entropy"] > 6.8:
+                    if float(section["entropy"]) > 6.8:
                         self.data.append({"section" : section})
                         total_compressed += int(section["size_of_data"], 16)
                 


### PR DESCRIPTION
Need detect call's to kernel32.dll -> IsDebuggerPresent  

i Try 

def on_call(self, call, process):
        indicators = [
            ".*user32.dll",
            ".*kernel32.dll",
        ]
        for indicator in indicators:
            if self.check_api(pattern='isdebuggerpresent'):
                return True
            return False

and another codes... 

anyone can help me ? 